### PR TITLE
[Delivers #178762750] nodejs-winrm package should support more robust shell command output and signals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-winrm",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Make WinRM service calls from NodeJS",
   "main": "index.js",
   "scripts": {

--- a/src/base-request.js
+++ b/src/base-request.js
@@ -43,7 +43,7 @@ module.exports.getSoapHeaderRequest = function (_params) {
                     'xml:lang': 'en-US'
                 }
             },
-            'wsman:OperationTimeout': 'PT60S',
+            'wsman:OperationTimeout': _params['operationTimeout'] || 'PT60S',
             'wsa:Action': {
                 '@': {
                     'mustUnderstand': 'true'

--- a/src/command.js
+++ b/src/command.js
@@ -190,7 +190,6 @@ module.exports.doSignal = async function (_params) {
         _params.authOnce = undefined;
     }
 
-    console.log(req);
     var result = await winrm_http_req.sendHttp(req, _params.host, _params.port, _params.path, auth, _params.agent, _params.requestOptions);
 
     if (result['s:Envelope']['s:Body'][0]['s:Fault']) {

--- a/src/command.js
+++ b/src/command.js
@@ -6,7 +6,8 @@ let util = require('./util.js');
 function constructRunCommandRequest(_params) {
     var res = winrm_soap_req.getSoapHeaderRequest({
         'action': 'http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command',
-        'shellId': _params.shellId
+        'shellId': _params.shellId,
+        'operationTimeout': _params.operationTimeout
     });
 
     res['s:Header']['wsman:OptionSet'] = [];
@@ -36,7 +37,8 @@ function constructRunCommandRequest(_params) {
 function constructReceiveOutputRequest(_params) {
     var res = winrm_soap_req.getSoapHeaderRequest({
         'action': 'http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive',
-        'shellId': _params.shellId
+        'shellId': _params.shellId,
+        'operationTimeout': _params.operationTimeout
     });
 
     res['s:Body'] = {

--- a/src/command.js
+++ b/src/command.js
@@ -103,7 +103,7 @@ function generatePowershellCommand(_params) {
         '-InputFormat', 'Text',
         '-Command', '"& {',
         _params.command,
-        '}"'
+        '; exit $LASTEXITCODE}"'
     );
     return args.join(' ');
 }

--- a/src/enumerate.js
+++ b/src/enumerate.js
@@ -7,7 +7,8 @@ function constructBeginEnumerationRequest(_params) {
     var res = winrm_soap_req.getSoapHeaderRequest({
         'resource_uri': _params.resourceUri || 'http://schemas.dmtf.org/wbem/wscim/1/*',
         'action': 'http://schemas.xmlsoap.org/ws/2004/09/enumeration/Enumerate',
-        'selectorSet': _params.selectorSet
+        'selectorSet': _params.selectorSet,
+        'operationTimeout': _params.operationTimeout
     });
 
     res['s:Body'] = {
@@ -34,7 +35,8 @@ function constructBeginEnumerationRequest(_params) {
 function constructPullEnumerationRequest(_params) {
     var res = winrm_soap_req.getSoapHeaderRequest({
         'resource_uri': _params.resourceUri || 'http://schemas.dmtf.org/wbem/wscim/1/*',
-        'action': 'http://schemas.xmlsoap.org/ws/2004/09/enumeration/Pull'
+        'action': 'http://schemas.xmlsoap.org/ws/2004/09/enumeration/Pull',
+        'operationTimeout': _params.operationTimeout
     });
 
     res['s:Body'] = {
@@ -51,7 +53,8 @@ function constructPullEnumerationRequest(_params) {
 function constructReleaseEnumerationRequest(_params) {
     var res = winrm_soap_req.getSoapHeaderRequest({
         'resource_uri': _params.resourceUri || 'http://schemas.dmtf.org/wbem/wscim/1/*',
-        'action': 'http://schemas.xmlsoap.org/ws/2004/09/enumeration/Release'
+        'action': 'http://schemas.xmlsoap.org/ws/2004/09/enumeration/Release',
+        'operationTimeout': _params.operationTimeout
     });
 
     res['s:Body'] = {

--- a/src/invoke.js
+++ b/src/invoke.js
@@ -7,7 +7,8 @@ function constructInvokeActionRequest(_params) {
     var res = winrm_soap_req.getSoapHeaderRequest({
         'resource_uri': _params.resourceUri,
         'action': _params.actionUri || (util.removeQueryString(_params.resourceUri) + '/' + _params.action),
-        'selectorSet': _params.selectorSet
+        'selectorSet': _params.selectorSet,
+        'operationTimeout': _params.operationTimeout
     });
 
     res['s:Body'] = {

--- a/src/shell.js
+++ b/src/shell.js
@@ -3,9 +3,10 @@ let winrm_soap_req = require('./base-request.js');
 let winrm_http_req = require('./http.js');
 let util = require('./util.js');
 
-function constructCreateShellRequest() {
+function constructCreateShellRequest(_params) {
     var res = winrm_soap_req.getSoapHeaderRequest({
-        'action': 'http://schemas.xmlsoap.org/ws/2004/09/transfer/Create'
+        'action': 'http://schemas.xmlsoap.org/ws/2004/09/transfer/Create',
+        'operationTimeout': _params.operationTimeout
     });
 
     res['s:Header']['wsman:OptionSet'] = [];
@@ -38,7 +39,8 @@ function constructDeleteShellRequest(_params) {
     var res = winrm_soap_req.getSoapHeaderRequest({
         'resource_uri': 'http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd',
         'action': 'http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete',
-        'shellId': _params.shellId
+        'shellId': _params.shellId,
+        'operationTimeout': _params.operationTimeout
     });
 
     res['s:Body'] = {};
@@ -47,7 +49,7 @@ function constructDeleteShellRequest(_params) {
 }
 
 module.exports.doCreateShell = async function (_params) {
-    var req = constructCreateShellRequest();
+    var req = constructCreateShellRequest(_params);
 
     var auth = _params.auth;
     if (_params.authOnce) {


### PR DESCRIPTION
- Add onReceive with commandState and individual stream output to receive all command output (call in async loop until `commandState === 'Done'` to receive all output)
- Add ability to send signals like ctrl_c/SIGINT to commands to terminate them
- Add operationTimeout support to allow for early termination/timeouts